### PR TITLE
근무 시간 화면 출력 기능 구현 / 데이터베이스 연결 및 관련 기능 구현

### DIFF
--- a/leavetheoffice/ios/Flutter/Debug.xcconfig
+++ b/leavetheoffice/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/leavetheoffice/ios/Flutter/Release.xcconfig
+++ b/leavetheoffice/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/leavetheoffice/ios/Podfile
+++ b/leavetheoffice/ios/Podfile
@@ -1,0 +1,38 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/leavetheoffice/lib/components/staff_component.dart
+++ b/leavetheoffice/lib/components/staff_component.dart
@@ -9,11 +9,12 @@ import '../data/staff_info_data.dart';
 
 class Staff extends StatefulWidget {
   Staff_info info;
+  List<Attendance> todayAtt;
 
-  Staff(this.info);
+  Staff(this.info, this.todayAtt);
 
   @override
-  State createState() => _StaffState(info);
+  State createState() => _StaffState(info, todayAtt);
 }
 
 class _StaffState extends State<Staff> {
@@ -23,12 +24,13 @@ class _StaffState extends State<Staff> {
 
   // Staff info
   Staff_info info;
+  List<Attendance> todayAtt;
 
   // Component variables
   String timeMessage = beforeWork;
   String buttonMessage = buttonTexts[0];
 
-  _StaffState(this.info);
+  _StaffState(this.info, this.todayAtt);
 
   @override
   Widget build(BuildContext context) {
@@ -122,6 +124,18 @@ class _StaffState extends State<Staff> {
       _setTimer();
       setState(() {});
     }
+
+    for(int i =0; i < todayAtt.length; i++){
+      if(todayAtt[i].id == info.id){
+        info.isWorking = true;
+        info.setStartTime(DateTime(todayAtt[i].date.year, todayAtt[i].date.month, todayAtt[i].date.day,
+            todayAtt[i].start.hour, todayAtt[i].start.min, todayAtt[i].start.sec), isSaved: true);
+        buttonMessage = buttonTexts[1];
+        _updateWorkHours();
+        _setTimer();
+        setState(() {});
+      }
+    }
   }
 
   @override
@@ -183,7 +197,7 @@ class _StaffState extends State<Staff> {
     DateTime now = DateTime.now();
     int nowSec = now.hour * 360 + now.minute * 60 + now.second;
     timeMessage =
-        "${((nowSec - info.startTimeSec) / 60).floor()}시간 ${(nowSec - info.startTimeSec) % 60}분";
+        "${((nowSec - info.startTimeSec) / 360).floor()}시간 ${((nowSec - info.startTimeSec) / 60).floor()}분";
 
     setState(() {});
   }

--- a/leavetheoffice/lib/components/staff_component.dart
+++ b/leavetheoffice/lib/components/staff_component.dart
@@ -1,12 +1,13 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 class Staff extends StatefulWidget {
-
   String name;
   String roll;
 
-  Staff (String name, String roll){
+  Staff(String name, String roll) {
     this.name = name;
     this.roll = roll;
   }
@@ -15,28 +16,33 @@ class Staff extends StatefulWidget {
   State createState() => _StaffState(name, roll);
 }
 
-class _StaffState extends State<Staff>{
+class _StaffState extends State<Staff> {
+  // Constants
+  static const List<String> buttonTexts = ["출근하기", "퇴근하기"];
+  static const String beforeWork = "출근 전";
 
+  // Staff info
   String name;
-
   String roll;
 
-  String timeLeft = "출근전";
-
+  // Time management
+  Timer _timer;
   bool isWorking = false;
+  int workMin = 0;
 
+  // DB
   DateTime workStartTime;
-
   DateTime workEndTime;
 
-  String buttonMessage = "출근하기";
+  // Component variables
+  String timeMessage = beforeWork;
+  String buttonMessage = buttonTexts[0];
 
-  _StaffState(String name, String roll){
+  _StaffState(String name, String roll) {
     this.name = name;
     this.roll = roll;
     this.isWorking = false;
   }
-
 
   @override
   Widget build(BuildContext context) {
@@ -62,7 +68,7 @@ class _StaffState extends State<Staff>{
             flex: 55,
             child: Center(
               child: Text(
-                '환영합니다. ❤ ${roll !=null ? roll : "담당 로딩 실패.."}',
+                '환영합니다. ❤ ${roll != null ? roll : "담당 로딩 실패.."}',
                 style: TextStyle(
                   fontSize: 18,
                 ),
@@ -73,7 +79,7 @@ class _StaffState extends State<Staff>{
             flex: 70,
             child: Center(
               child: Text(
-                name !=null ? name : "이름 로딩 실패..",
+                name != null ? name : "이름 로딩 실패..",
                 style: TextStyle(
                   fontWeight: FontWeight.bold,
                   fontSize: 48,
@@ -86,11 +92,11 @@ class _StaffState extends State<Staff>{
             flex: 50,
             child: Center(
               child: Text(
-                timeLeft,
+                timeMessage,
                 style: TextStyle(
                   fontWeight: FontWeight.bold,
                   fontSize: 18,
-                  color: Colors.red,
+                  color: Color(0xFFE05764),
                 ),
               ),
             ),
@@ -109,7 +115,6 @@ class _StaffState extends State<Staff>{
                     horizontal: 140,
                     vertical: 15,
                   ),
-
                 ),
                 child: Text(buttonMessage),
                 onPressed: _buttonClicked,
@@ -122,20 +127,42 @@ class _StaffState extends State<Staff>{
   }
 
   void _buttonClicked() {
-
     debugPrint("clicked");
     //click when start working
-    if(!isWorking){
-
+    if (!isWorking) {
       isWorking = true;
-      workStartTime = DateTime.now();
 
-      debugPrint(new DateFormat.Hms().format(workStartTime));
+      workStartTime = DateTime.now();
+      _updateWorkHours();
+      buttonMessage = buttonTexts[1];
+
+      _timer = new Timer.periodic(Duration(seconds: 1), (timer) {
+        _updateWorkHours();
+      });
 
       //click during working
-    }else{
+    } else {
       isWorking = false;
+      //show dialog
+      buttonMessage = buttonTexts[0];
+      _timer?.cancel();
     }
 
+    setState(() {
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  void _updateWorkHours() {
+    debugPrint("$name, $workMin");
+    setState(() {
+      timeMessage = "${(workMin / 60).floor()}시간 ${workMin % 60}분";
+    });
+    workMin++;
   }
 }

--- a/leavetheoffice/lib/components/staff_component.dart
+++ b/leavetheoffice/lib/components/staff_component.dart
@@ -6,14 +6,12 @@ import 'package:leavetheoffice/provider.dart';
 import '../data/staff_info_data.dart';
 
 class Staff extends StatefulWidget {
-  int index;
+  Staff_info info;
 
-  Staff(int index, String name, String roll) {
-    this.index = index;
-  }
+  Staff(this.info);
 
   @override
-  State createState() => _StaffState(index);
+  State createState() => _StaffState(info);
 }
 
 class _StaffState extends State<Staff> {
@@ -22,17 +20,13 @@ class _StaffState extends State<Staff> {
   static const String beforeWork = "출근 전";
 
   // Staff info정
-  int index;
   Staff_info info;
 
   // Component variables
   String timeMessage = beforeWork;
   String buttonMessage = buttonTexts[0];
 
-  _StaffState(int index) {
-    this.index = index;
-    info = getDataManager().getStaffInfo(index);
-  }
+  _StaffState(this.info);
 
   @override
   Widget build(BuildContext context) {

--- a/leavetheoffice/lib/components/staff_component.dart
+++ b/leavetheoffice/lib/components/staff_component.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 class Staff extends StatefulWidget {
   String name;
@@ -144,7 +143,10 @@ class _StaffState extends State<Staff> {
     } else {
       isWorking = false;
       //show dialog
+      timeMessage = beforeWork;
+      workMin = 0;
       buttonMessage = buttonTexts[0];
+      workEndTime = DateTime.now();
       _timer?.cancel();
     }
 

--- a/leavetheoffice/lib/components/staff_component.dart
+++ b/leavetheoffice/lib/components/staff_component.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:leavetheoffice/data/att_data_format.dart';
 import 'package:leavetheoffice/data/attendance.dart';
-import 'package:leavetheoffice/provider.dart';
 
 import '../data/staff_info_data.dart';
 
@@ -125,8 +123,9 @@ class _StaffState extends State<Staff> {
       setState(() {});
     }
 
+    // 애플리케이션이 중간에 중단되었다가 재시동된 경우 판단
     for(int i =0; i < todayAtt.length; i++){
-      if(todayAtt[i].id == info.id){
+      if(todayAtt[i].id == info.id && todayAtt[i].end == null){
         info.isWorking = true;
         info.setStartTime(DateTime(todayAtt[i].date.year, todayAtt[i].date.month, todayAtt[i].date.day,
             todayAtt[i].start.hour, todayAtt[i].start.min, todayAtt[i].start.sec), isSaved: true);
@@ -197,7 +196,7 @@ class _StaffState extends State<Staff> {
     DateTime now = DateTime.now();
     int nowSec = now.hour * 360 + now.minute * 60 + now.second;
     timeMessage =
-        "${((nowSec - info.startTimeSec) / 360).floor()}시간 ${((nowSec - info.startTimeSec) / 60).floor()}분";
+        "${((nowSec - info.startTimeSec) / 3600).floor()}시간 ${((nowSec - info.startTimeSec) / 60).floor()}분";
 
     setState(() {});
   }

--- a/leavetheoffice/lib/components/staff_component.dart
+++ b/leavetheoffice/lib/components/staff_component.dart
@@ -16,7 +16,6 @@ class Staff extends StatefulWidget {
   State createState() => _StaffState(index);
 }
 
-
 class _StaffState extends State<Staff> {
   // Constants
   static const List<String> buttonTexts = ["출근하기", "퇴근하기"];
@@ -119,7 +118,9 @@ class _StaffState extends State<Staff> {
 
   @override
   void initState() {
-    if(info.timer != null && info.isWorking){     // 화면에 그려지지 않아 삭제된 컴포넌트의 타이머를 재생
+    if (info.timer != null && info.isWorking) {
+      // 화면에 그려지지 않아 삭제된 컴포넌트인 경우, 타이머를 다시 시작
+      buttonMessage = buttonTexts[1];
       _updateWorkHours();
       _setTimer();
     }
@@ -127,47 +128,46 @@ class _StaffState extends State<Staff> {
 
   @override
   void dispose() {
-    getDataManager().endTimer(index);
+    info.endTimer();
     super.dispose();
   }
 
   void _buttonClicked() {
-    debugPrint("clicked");
-    //click when start working
     if (!info.isWorking) {
+      //click when start working
+      // update data
       info.switchIsWorking();
-
       info.setStartTime(DateTime.now());
-      _updateWorkHours();
+      //update text component
       buttonMessage = buttonTexts[1];
 
       _setTimer();
-
-      //click during working
+      _updateWorkHours();
     } else {
-      getDataManager().switchIsWorking(index);
-      //show dialog
+      //click during working
+      // TODO: SHOW DIALOG
+      // update data
+      info.switchIsWorking();
+      info.setEndTime(DateTime.now());
+      // updqte text components
       timeMessage = beforeWork;
       buttonMessage = buttonTexts[0];
-      info.setEndTime(DateTime.now());
-      getDataManager().endTimer(index);
-      info.switchIsWorking();
-    }
 
-    setState(() {
-    });
+      info.endTimer();
+    }
   }
 
   void _updateWorkHours() {
     DateTime now = DateTime.now();
     int nowSec = now.hour * 360 + now.minute * 60 + now.second;
-    setState(() {
-      timeMessage = "${((nowSec - info.startTimeSec) / 60).floor()}시간 ${(nowSec - info.startTimeSec) % 60}분";
-    });
+    timeMessage =
+        "${((nowSec - info.startTimeSec) / 60).floor()}시간 ${(nowSec - info.startTimeSec) % 60}분";
+
+    setState(() {});
   }
 
-  void _setTimer(){
-    getDataManager().startTimer(index, new Timer.periodic(Duration(seconds: 1), (t){
+  void _setTimer() {
+    info.startTimer(new Timer.periodic(Duration(seconds: 1), (t) {
       _updateWorkHours();
     }));
   }

--- a/leavetheoffice/lib/components/staff_component.dart
+++ b/leavetheoffice/lib/components/staff_component.dart
@@ -123,6 +123,7 @@ class _StaffState extends State<Staff> {
       buttonMessage = buttonTexts[1];
       _updateWorkHours();
       _setTimer();
+      setState(() {});
     }
   }
 
@@ -145,15 +146,36 @@ class _StaffState extends State<Staff> {
       _updateWorkHours();
     } else {
       //click during working
-      // TODO: SHOW DIALOG
-      // update data
-      info.switchIsWorking();
-      info.setEndTime(DateTime.now());
-      // update text components
-      timeMessage = beforeWork;
-      buttonMessage = buttonTexts[0];
+      showDialog(
+          context: context,
+          builder: (context) {
+            return AlertDialog(
+              title: Text("퇴근하기"),
+              content: Text("퇴근하시겠습니까?"),
+              actions: [
+                TextButton(
+                    onPressed: () {
+                      Navigator.pop(context);
+                    },
+                    child: Text("취소")),
+                ElevatedButton(
+                    onPressed: () {
+                      // update data
+                      info.switchIsWorking();
+                      info.setEndTime(DateTime.now());
+                      // update text components
+                      timeMessage = beforeWork;
+                      buttonMessage = buttonTexts[0];
 
-      info.endTimer();
+                      info.endTimer();
+                      setState(() {});
+
+                      Navigator.pop(context);
+                    },
+                    child: Text("확인")),
+              ],
+            );
+          });
     }
   }
 

--- a/leavetheoffice/lib/components/staff_component.dart
+++ b/leavetheoffice/lib/components/staff_component.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:leavetheoffice/data/att_data_format.dart';
+import 'package:leavetheoffice/data/attendance.dart';
 import 'package:leavetheoffice/provider.dart';
 
 import '../data/staff_info_data.dart';
@@ -19,7 +21,7 @@ class _StaffState extends State<Staff> {
   static const List<String> buttonTexts = ["출근하기", "퇴근하기"];
   static const String beforeWork = "출근 전";
 
-  // Staff info정
+  // Staff info
   Staff_info info;
 
   // Component variables
@@ -112,6 +114,7 @@ class _StaffState extends State<Staff> {
 
   @override
   void initState() {
+    DateTime now = DateTime.now();
     if (info.timer != null && info.isWorking) {
       // 화면에 그려지지 않아 삭제된 컴포넌트인 경우, 타이머를 다시 시작
       buttonMessage = buttonTexts[1];
@@ -128,11 +131,13 @@ class _StaffState extends State<Staff> {
   }
 
   void _buttonClicked() {
+    debugPrint(info.id.toString());
     if (!info.isWorking) {
       //click when start working
       // update data
       info.switchIsWorking();
       info.setStartTime(DateTime.now());
+      debugPrint(DateTime.now().toString());
       //update text component
       buttonMessage = buttonTexts[1];
 

--- a/leavetheoffice/lib/components/staff_component.dart
+++ b/leavetheoffice/lib/components/staff_component.dart
@@ -21,7 +21,7 @@ class _StaffState extends State<Staff> {
   static const List<String> buttonTexts = ["출근하기", "퇴근하기"];
   static const String beforeWork = "출근 전";
 
-  // Staff info
+  // Staff info정
   int index;
   Staff_info info;
 
@@ -149,7 +149,7 @@ class _StaffState extends State<Staff> {
       // update data
       info.switchIsWorking();
       info.setEndTime(DateTime.now());
-      // updqte text components
+      // update text components
       timeMessage = beforeWork;
       buttonMessage = buttonTexts[0];
 
@@ -158,6 +158,7 @@ class _StaffState extends State<Staff> {
   }
 
   void _updateWorkHours() {
+    // 시간 갱신 및 화면 새로고침
     DateTime now = DateTime.now();
     int nowSec = now.hour * 360 + now.minute * 60 + now.second;
     timeMessage =
@@ -167,6 +168,7 @@ class _StaffState extends State<Staff> {
   }
 
   void _setTimer() {
+    // 타이머 설
     info.startTimer(new Timer.periodic(Duration(seconds: 1), (t) {
       _updateWorkHours();
     }));

--- a/leavetheoffice/lib/components/staff_list_component.dart
+++ b/leavetheoffice/lib/components/staff_list_component.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:leavetheoffice/components/staff_component.dart';
+import 'package:leavetheoffice/data/att_data_format.dart';
+import 'package:leavetheoffice/data/attendance.dart';
 import 'package:leavetheoffice/data/staff_info_data.dart';
 import 'package:leavetheoffice/provider.dart';
 
@@ -13,16 +15,17 @@ class StaffList extends StatefulWidget {
 class _StaffListState extends State<StaffList> {
   @override
   Widget build(BuildContext context) {
+    DateTime now = DateTime.now();
     return Expanded(
       child: FutureBuilder(
-          future: getDataManager().staffList(),
-          builder: (context, snapshot) {
+          future: Future.wait([getDataManager().staffList(), getDataManager().getTodayAtts(Date(now.year, now.month, now.day))]),
+          builder: (context, AsyncSnapshot<List<dynamic>> snapshot) {
             if (snapshot.connectionState == ConnectionState.waiting) {
               return Center(child: CircularProgressIndicator());
             }
             if (snapshot.hasData) {
-              List<Staff_info> staffList = snapshot.data;
-              debugPrint(staffList.isNotEmpty ? staffList[0].name : "List Empty");
+              List<Staff_info> staffList = snapshot.data[0];
+              List<Attendance> todayAtt = snapshot.data[1];
               return GridView.builder(
                 shrinkWrap: true,
                 padding: EdgeInsets.symmetric(
@@ -30,8 +33,7 @@ class _StaffListState extends State<StaffList> {
                 ),
                 itemCount: staffList.length,
                 itemBuilder: (context, index) {
-                  return Staff(
-                      staffList[index]);
+                  return Staff(staffList[index], todayAtt);
                 },
                 gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
                   crossAxisCount: 3,

--- a/leavetheoffice/lib/components/staff_list_component.dart
+++ b/leavetheoffice/lib/components/staff_list_component.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:leavetheoffice/components/staff_component.dart';
 import 'package:leavetheoffice/data/staff_info_data.dart';
 
+import '../data/staff_info_data.dart';
+
 class StaffList extends StatefulWidget {
   @override
   State createState() => _StaffListState();
@@ -15,7 +17,8 @@ class _StaffListState extends State<StaffList> {
       Staff_info("김도연", "DEVELOPER"),
       Staff_info("박지윤", "DEVELOPER"),
       Staff_info("박정아", "PM"),
-      Staff_info("상한규", "INTERN")
+      Staff_info("상한규", "INTERN"),
+      Staff_info("당병진", "DEVELOPER")
     ];
 
     GridView memberGrid = GridView.builder(
@@ -33,7 +36,7 @@ class _StaffListState extends State<StaffList> {
       ),
     );
 
-    return Container(
+    return Expanded(
       child: memberGrid,
     );
   }

--- a/leavetheoffice/lib/components/staff_list_component.dart
+++ b/leavetheoffice/lib/components/staff_list_component.dart
@@ -1,11 +1,8 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:leavetheoffice/components/staff_component.dart';
 import 'package:leavetheoffice/data/staff_info_data.dart';
 import 'package:leavetheoffice/provider.dart';
 
-import '../data/staff_info_data.dart';
 import '../data/staff_info_data.dart';
 
 class StaffList extends StatefulWidget {
@@ -16,25 +13,34 @@ class StaffList extends StatefulWidget {
 class _StaffListState extends State<StaffList> {
   @override
   Widget build(BuildContext context) {
-    List<Staff_info> staffList = getDataManager().getStaffs();
-
-    GridView memberGrid = GridView.builder(
-      shrinkWrap: true,
-      padding: EdgeInsets.symmetric(
-        horizontal: 20,
-      ),
-      itemCount: staffList.length,
-      itemBuilder: (context, index) {
-        return Staff(index, staffList[index].name, staffList[index].roll);
-      },
-      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: 3,
-        childAspectRatio: 1.45,
-      ),
-    );
-
     return Expanded(
-      child: memberGrid,
+      child: FutureBuilder(
+          future: getDataManager().staffList(),
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return Center(child: CircularProgressIndicator());
+            }
+            if (snapshot.hasData) {
+              List<Staff_info> staffList = snapshot.data;
+              debugPrint(staffList.isNotEmpty ? staffList[0].name : "List Empty");
+              return GridView.builder(
+                shrinkWrap: true,
+                padding: EdgeInsets.symmetric(
+                  horizontal: 20,
+                ),
+                itemCount: staffList.length,
+                itemBuilder: (context, index) {
+                  return Staff(
+                      staffList[index]);
+                },
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 3,
+                  childAspectRatio: 1.45,
+                ),
+              );
+            }
+            return Center(child: Text("데이터 불러오기 실패"));
+          }),
     );
   }
 }

--- a/leavetheoffice/lib/components/staff_list_component.dart
+++ b/leavetheoffice/lib/components/staff_list_component.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:leavetheoffice/components/staff_component.dart';
 import 'package:leavetheoffice/data/staff_info_data.dart';
+import 'package:leavetheoffice/provider.dart';
 
+import '../data/staff_info_data.dart';
 import '../data/staff_info_data.dart';
 
 class StaffList extends StatefulWidget {
@@ -12,14 +16,7 @@ class StaffList extends StatefulWidget {
 class _StaffListState extends State<StaffList> {
   @override
   Widget build(BuildContext context) {
-    List<Staff_info> staffList = [
-      Staff_info("이아영", "DESIGNER"),
-      Staff_info("김도연", "DEVELOPER"),
-      Staff_info("박지윤", "DEVELOPER"),
-      Staff_info("박정아", "PM"),
-      Staff_info("상한규", "INTERN"),
-      Staff_info("당병진", "DEVELOPER")
-    ];
+    List<Staff_info> staffList = getDataManager().getStaffs();
 
     GridView memberGrid = GridView.builder(
       shrinkWrap: true,
@@ -28,7 +25,7 @@ class _StaffListState extends State<StaffList> {
       ),
       itemCount: staffList.length,
       itemBuilder: (context, index) {
-        return Staff(staffList[index].name, staffList[index].roll);
+        return Staff(index, staffList[index].name, staffList[index].roll);
       },
       gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: 3,

--- a/leavetheoffice/lib/data/att_data_format.dart
+++ b/leavetheoffice/lib/data/att_data_format.dart
@@ -7,7 +7,7 @@ class Date{
 
   String toString(){
     super.toString();
-    return year.toString() + "/" + month.toString() + "/" + day.toString();
+    return year.toString() + "-" + month.toString() + "-" + day.toString();
   }
 }
 

--- a/leavetheoffice/lib/data/att_data_format.dart
+++ b/leavetheoffice/lib/data/att_data_format.dart
@@ -1,4 +1,7 @@
+//데이터 관리에 용이하도록 Date class와 Time class 정의
+
 class Date{
+  // 날짜를 저장하기 위한 포맷
   int year;
   int month;
   int day;
@@ -6,12 +9,14 @@ class Date{
   Date(this.year, this.month, this.day);
 
   String toString(){
+    // SQLite는 DateTime 형식을 지원하지 않기 때문에 일정한 규칙에 따라 문자열로 변환
     super.toString();
     return year.toString() + "-" + month.toString() + "-" + day.toString();
   }
 }
 
 class Time{
+  // 시간을 저장하기 위한 포맷
   int hour;
   int min;
   int sec;

--- a/leavetheoffice/lib/data/att_data_format.dart
+++ b/leavetheoffice/lib/data/att_data_format.dart
@@ -1,0 +1,25 @@
+class Date{
+  int year;
+  int month;
+  int day;
+
+  Date(this.year, this.month, this.day);
+
+  String toString(){
+    super.toString();
+    return year.toString() + "/" + month.toString() + "/" + day.toString();
+  }
+}
+
+class Time{
+  int hour;
+  int min;
+  int sec;
+
+  Time(this.hour, this.min, this.sec);
+
+  String toString(){
+    super.toString();
+    return hour.toString() + ":" + min.toString() + ":" + sec.toString();
+  }
+}

--- a/leavetheoffice/lib/data/attendance.dart
+++ b/leavetheoffice/lib/data/attendance.dart
@@ -1,0 +1,14 @@
+class Attendance{
+  //DB
+  static const String attTableName = "attendance";
+  static const String columnId = "id";
+  static const String columnDate = "date";
+  static const String columnStart = "start";
+  static const String columnEnd = "end";
+
+  //variable
+  int id;
+  DateTime date, start, end;
+
+  Attendance(this.id);
+}

--- a/leavetheoffice/lib/data/attendance.dart
+++ b/leavetheoffice/lib/data/attendance.dart
@@ -1,8 +1,9 @@
 import 'package:leavetheoffice/data/att_data_format.dart';
-import 'package:leavetheoffice/provider.dart';
 
 class Attendance{
-  //DB
+  // 근태 관리에 필요한 변수들을 이 클래스로 관리
+
+  //DB table / column 이름 정의
   static const String attTableName = "attendance";
   static const String columnId = "id";
   static const String columnDate = "date";
@@ -12,7 +13,7 @@ class Attendance{
   //variable
   int id;
   Date date;
-  Time start, end;
+  Time start, end;    // 근무 시작시간, 끝 시간
 
   Attendance(this.id, this.date, this.start, {this.end});
 }

--- a/leavetheoffice/lib/data/attendance.dart
+++ b/leavetheoffice/lib/data/attendance.dart
@@ -1,3 +1,6 @@
+import 'package:leavetheoffice/data/att_data_format.dart';
+import 'package:leavetheoffice/provider.dart';
+
 class Attendance{
   //DB
   static const String attTableName = "attendance";
@@ -8,7 +11,8 @@ class Attendance{
 
   //variable
   int id;
-  DateTime date, start, end;
+  Date date;
+  Time start, end;
 
-  Attendance(this.id);
+  Attendance(this.id, this.date, this.start, {this.end});
 }

--- a/leavetheoffice/lib/data/data_manager.dart
+++ b/leavetheoffice/lib/data/data_manager.dart
@@ -24,20 +24,4 @@ class DataManager{
   Staff_info getStaffInfo(int index){
     return _staffs[index];
   }
-
-  void startTimer(int index, Timer timer){
-    _staffs[index].timer = timer;
-  }
-
-  void endTimer(int index){
-    _staffs[index].timer?.cancel();
-  }
-
-  bool isWorking(int index){
-    return _staffs[index].isWorking;
-  }
-
-  void switchIsWorking(int index){
-    _staffs[index].isWorking = !_staffs[index].isWorking;
-  }
 }

--- a/leavetheoffice/lib/data/data_manager.dart
+++ b/leavetheoffice/lib/data/data_manager.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:leavetheoffice/data/attendance.dart';
 import 'package:leavetheoffice/provider.dart';
 import 'package:sqflite/sqflite.dart';
 
+import 'att_data_format.dart';
 import 'staff_info_data.dart';
 
 class DataManager{
@@ -15,10 +17,9 @@ class DataManager{
     Database db = await getDatabaseHelper().getDatabase();
     List<Map<String, dynamic>> rows = await db.query(Staff_info.memTableName);
     if(rows.isEmpty){
-      initData();
-      List<Map<String, dynamic>> rows = await db.query(Staff_info.memTableName);
+      await initData();
+      rows = await db.query(Staff_info.memTableName);
     }
-    debugPrint(rows.isNotEmpty?"rows is not empty":"rows is empty");
     return rows.map((row) => getDatabaseHelper().rowToMem(row)).toList();
   }
 
@@ -36,13 +37,29 @@ class DataManager{
     Database db = await getDatabaseHelper().getDatabase();
     db.delete(Staff_info.memTableName, where: "${Staff_info.columnId} = ?", whereArgs: [id]);
   }
+
+  Future<void> addAttData(Attendance att) async {
+    Database db = await getDatabaseHelper().getDatabase();
+    db.insert(Attendance.attTableName, getDatabaseHelper().attToRow(att));
+  }
+
+  Future<void> updateAttData(Attendance att, int id, Date date) async {
+    Database db = await getDatabaseHelper().getDatabase();
+    db.update(Attendance.attTableName, getDatabaseHelper().attToRow(att), where: "${Attendance.columnId} = ? and ${Attendance.columnDate} = ?", whereArgs: [id, date.toString()]);
+  }
+
+  Future<Attendance> getAtt(int id, Date date) async {
+    Database db = await getDatabaseHelper().getDatabase();
+    List<Map<String,dynamic>> row = await db.query(Attendance.attTableName, where: "${Attendance.columnId} = ? and ${Attendance.columnDate} = ?", whereArgs: [id, date.toString()]);
+    return getDatabaseHelper().rowToAtt(row.single);
+  }
   
-  void initData(){
-    addStaff(new Staff_info("이아영", "DESIGNER"));
-    addStaff(new Staff_info("김도연", "DEVELOPER"));
-    addStaff(new Staff_info("박지윤", "DEVELOPER"));
-    addStaff(new Staff_info("박정아", "PM"));
-    addStaff(new Staff_info("상한규", "INTERN"));
-    addStaff(new Staff_info("당병진", "DEVELOPER"));
+  Future<void> initData() async{
+    await addStaff(new Staff_info("이아영", "DESIGNER"));
+    await addStaff(new Staff_info("김도연", "DEVELOPER"));
+    await addStaff(new Staff_info("박지윤", "DEVELOPER"));
+    await addStaff(new Staff_info("박정아", "PM"));
+    await addStaff(new Staff_info("상한규", "INTERN"));
+    await addStaff(new Staff_info("당병진", "DEVELOPER"));
   }
 }

--- a/leavetheoffice/lib/data/data_manager.dart
+++ b/leavetheoffice/lib/data/data_manager.dart
@@ -1,0 +1,43 @@
+import 'dart:async';
+
+import 'staff_info_data.dart';
+import 'staff_info_data.dart';
+
+class DataManager{
+  List<Staff_info> _staffs= [
+    Staff_info("이아영", "DESIGNER"),
+    Staff_info("김도연", "DEVELOPER"),
+    Staff_info("박지윤", "DEVELOPER"),
+    Staff_info("박정아", "PM"),
+    Staff_info("상한규", "INTERN"),
+    Staff_info("당병진", "DEVELOPER"),
+    Staff_info("Test", "test"),
+    Staff_info("Test", "teeest"),
+    Staff_info("Test2", "teeeeest"),
+    Staff_info("name", "roll")
+  ];
+
+  List<Staff_info> getStaffs(){
+    return _staffs;
+  }
+
+  Staff_info getStaffInfo(int index){
+    return _staffs[index];
+  }
+
+  void startTimer(int index, Timer timer){
+    _staffs[index].timer = timer;
+  }
+
+  void endTimer(int index){
+    _staffs[index].timer?.cancel();
+  }
+
+  bool isWorking(int index){
+    return _staffs[index].isWorking;
+  }
+
+  void switchIsWorking(int index){
+    _staffs[index].isWorking = !_staffs[index].isWorking;
+  }
+}

--- a/leavetheoffice/lib/data/data_manager.dart
+++ b/leavetheoffice/lib/data/data_manager.dart
@@ -14,6 +14,10 @@ class DataManager{
   Future<List<Staff_info>> staffList() async {
     Database db = await getDatabaseHelper().getDatabase();
     List<Map<String, dynamic>> rows = await db.query(Staff_info.memTableName);
+    if(rows.isEmpty){
+      initData();
+      List<Map<String, dynamic>> rows = await db.query(Staff_info.memTableName);
+    }
     debugPrint(rows.isNotEmpty?"rows is not empty":"rows is empty");
     return rows.map((row) => getDatabaseHelper().rowToMem(row)).toList();
   }
@@ -33,7 +37,7 @@ class DataManager{
     db.delete(Staff_info.memTableName, where: "${Staff_info.columnId} = ?", whereArgs: [id]);
   }
   
-  void init(){
+  void initData(){
     addStaff(new Staff_info("이아영", "DESIGNER"));
     addStaff(new Staff_info("김도연", "DEVELOPER"));
     addStaff(new Staff_info("박지윤", "DEVELOPER"));

--- a/leavetheoffice/lib/data/data_manager.dart
+++ b/leavetheoffice/lib/data/data_manager.dart
@@ -1,6 +1,3 @@
-import 'dart:async';
-
-import 'staff_info_data.dart';
 import 'staff_info_data.dart';
 
 class DataManager{

--- a/leavetheoffice/lib/data/data_manager.dart
+++ b/leavetheoffice/lib/data/data_manager.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:leavetheoffice/data/attendance.dart';
 import 'package:leavetheoffice/provider.dart';
 import 'package:sqflite/sqflite.dart';
@@ -6,17 +5,21 @@ import 'package:sqflite/sqflite.dart';
 import 'att_data_format.dart';
 import 'staff_info_data.dart';
 
-class DataManager{
+class DataManager {
   Future<Staff_info> getStaffInfo(int id) async {
+    // 지정된 한 명의 정보를 가져옴
     Database db = await getDatabaseHelper().getDatabase();
-    List<Map<String, dynamic>> row = await db.query(Staff_info.memTableName, where: "${Staff_info.columnId} = ?", whereArgs: [id]);
+    List<Map<String, dynamic>> row = await db.query(Staff_info.memTableName,
+        where: "${Staff_info.columnId} = ?", whereArgs: [id]);
     return getDatabaseHelper().rowToMem(row.single);
   }
 
   Future<List<Staff_info>> staffList() async {
+    // 저장된 모든 스탭의 정보를 가져옴
     Database db = await getDatabaseHelper().getDatabase();
     List<Map<String, dynamic>> rows = await db.query(Staff_info.memTableName);
-    if(rows.isEmpty){
+    if (rows.isEmpty) {
+      // 초기값(스타팅 멤버) 정보 삽입. 앱 설치 후 최초 1회 실행
       await initData();
       rows = await db.query(Staff_info.memTableName);
     }
@@ -24,46 +27,58 @@ class DataManager{
   }
 
   Future<void> addStaff(Staff_info newStaff) async {
+    // 스탭 정보를 데이터베이스에 추가함
     Database db = await getDatabaseHelper().getDatabase();
     db.insert(Staff_info.memTableName, getDatabaseHelper().memToRow(newStaff));
   }
 
   Future<void> updateStaff(int id, Staff_info info) async {
+    // 스탭 정보를 수정함
     Database db = await getDatabaseHelper().getDatabase();
-    db.update(Staff_info.memTableName, getDatabaseHelper().memToRow(info), where: "${Staff_info.columnId} = ?", whereArgs: [id]);
+    db.update(Staff_info.memTableName, getDatabaseHelper().memToRow(info),
+        where: "${Staff_info.columnId} = ?", whereArgs: [id]);
   }
 
   Future<void> deleteStaff(int id) async {
+    // 스텝 정보를 삭제함
     Database db = await getDatabaseHelper().getDatabase();
-    db.delete(Staff_info.memTableName, where: "${Staff_info.columnId} = ?", whereArgs: [id]);
+    db.delete(Staff_info.memTableName,
+        where: "${Staff_info.columnId} = ?", whereArgs: [id]);
   }
 
   Future<void> addAttData(Attendance att) async {
+    // 근태 기록을 추가함(출근하기 버튼 클릭 시 실행)
     Database db = await getDatabaseHelper().getDatabase();
     db.insert(Attendance.attTableName, getDatabaseHelper().attToRow(att));
   }
 
   Future<void> updateAttData(Attendance att, int id, Date date) async {
+    // 근태 기록을 수정함(퇴근하기 버튼 클릭 시 실행)
     Database db = await getDatabaseHelper().getDatabase();
-    db.update(Attendance.attTableName, getDatabaseHelper().attToRow(att), where: "${Attendance.columnId} = ? and ${Attendance.columnDate} = ?", whereArgs: [id, date.toString()]);
+    db.update(Attendance.attTableName, getDatabaseHelper().attToRow(att),
+        where: "${Attendance.columnId} = ? and ${Attendance.columnDate} = ?",
+        whereArgs: [id, date.toString()]);
   }
 
   Future<Attendance> getAtt(int id, Date date) async {
+    // 지정된 개인의 지정된 날짜 근태 기록을 가져옴
     Database db = await getDatabaseHelper().getDatabase();
-    List<Map<String,dynamic>> row = await db.query(Attendance.attTableName, where: "${Attendance.columnId} = ? and ${Attendance.columnDate} = ?", whereArgs: [id, date.toString()]);
+    List<Map<String, dynamic>> row = await db.query(Attendance.attTableName,
+        where: "${Attendance.columnId} = ? and ${Attendance.columnDate} = ?",
+        whereArgs: [id, date.toString()]);
     return getDatabaseHelper().rowToAtt(row.single);
   }
 
   Future<List<Attendance>> getTodayAtts(Date date) async {
+    // 오늘의 모든 근태 기록을 가져옴
     Database db = await getDatabaseHelper().getDatabase();
-    List<Map<String, dynamic>> rows = await db.query(Attendance.attTableName, where: "${Attendance.columnDate} = ?", whereArgs: [date.toString()]);
-    //debugPrint(rows[0][Attendance.columnId].toString());
+    List<Map<String, dynamic>> rows = await db.query(Attendance.attTableName,
+        where: "${Attendance.columnDate} = ?", whereArgs: [date.toString()]);
     return rows.map((row) => getDatabaseHelper().rowToAtt(row)).toList();
-
-    //return [Attendance(2, Date(2021, 04, 20), Time(9, 0, 1))];
   }
-  
-  Future<void> initData() async{
+
+  Future<void> initData() async {
+    // 앱 최초 설치/실행 시 추가되는 데이터
     await addStaff(new Staff_info("이아영", "DESIGNER"));
     await addStaff(new Staff_info("김도연", "DEVELOPER"));
     await addStaff(new Staff_info("박지윤", "DEVELOPER"));

--- a/leavetheoffice/lib/data/data_manager.dart
+++ b/leavetheoffice/lib/data/data_manager.dart
@@ -1,24 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:leavetheoffice/provider.dart';
+import 'package:sqflite/sqflite.dart';
+
 import 'staff_info_data.dart';
 
 class DataManager{
-  List<Staff_info> _staffs= [
-    Staff_info("이아영", "DESIGNER"),
-    Staff_info("김도연", "DEVELOPER"),
-    Staff_info("박지윤", "DEVELOPER"),
-    Staff_info("박정아", "PM"),
-    Staff_info("상한규", "INTERN"),
-    Staff_info("당병진", "DEVELOPER"),
-    Staff_info("Test", "test"),
-    Staff_info("Test", "teeest"),
-    Staff_info("Test2", "teeeeest"),
-    Staff_info("name", "roll")
-  ];
-
-  List<Staff_info> getStaffs(){
-    return _staffs;
+  Future<Staff_info> getStaffInfo(int id) async {
+    Database db = await getDatabaseHelper().getDatabase();
+    List<Map<String, dynamic>> row = await db.query(Staff_info.memTableName, where: "${Staff_info.columnId} = ?", whereArgs: [id]);
+    return getDatabaseHelper().rowToMem(row.single);
   }
 
-  Staff_info getStaffInfo(int index){
-    return _staffs[index];
+  Future<List<Staff_info>> staffList() async {
+    Database db = await getDatabaseHelper().getDatabase();
+    List<Map<String, dynamic>> rows = await db.query(Staff_info.memTableName);
+    debugPrint(rows.isNotEmpty?"rows is not empty":"rows is empty");
+    return rows.map((row) => getDatabaseHelper().rowToMem(row)).toList();
+  }
+
+  Future<void> addStaff(Staff_info newStaff) async {
+    Database db = await getDatabaseHelper().getDatabase();
+    db.insert(Staff_info.memTableName, getDatabaseHelper().memToRow(newStaff));
+  }
+
+  Future<void> updateStaff(int id, Staff_info info) async {
+    Database db = await getDatabaseHelper().getDatabase();
+    db.update(Staff_info.memTableName, getDatabaseHelper().memToRow(info), where: "${Staff_info.columnId} = ?", whereArgs: [id]);
+  }
+
+  Future<void> deleteStaff(int id) async {
+    Database db = await getDatabaseHelper().getDatabase();
+    db.delete(Staff_info.memTableName, where: "${Staff_info.columnId} = ?", whereArgs: [id]);
+  }
+  
+  void init(){
+    addStaff(new Staff_info("이아영", "DESIGNER"));
+    addStaff(new Staff_info("김도연", "DEVELOPER"));
+    addStaff(new Staff_info("박지윤", "DEVELOPER"));
+    addStaff(new Staff_info("박정아", "PM"));
+    addStaff(new Staff_info("상한규", "INTERN"));
+    addStaff(new Staff_info("당병진", "DEVELOPER"));
   }
 }

--- a/leavetheoffice/lib/data/data_manager.dart
+++ b/leavetheoffice/lib/data/data_manager.dart
@@ -53,6 +53,15 @@ class DataManager{
     List<Map<String,dynamic>> row = await db.query(Attendance.attTableName, where: "${Attendance.columnId} = ? and ${Attendance.columnDate} = ?", whereArgs: [id, date.toString()]);
     return getDatabaseHelper().rowToAtt(row.single);
   }
+
+  Future<List<Attendance>> getTodayAtts(Date date) async {
+    Database db = await getDatabaseHelper().getDatabase();
+    List<Map<String, dynamic>> rows = await db.query(Attendance.attTableName, where: "${Attendance.columnDate} = ?", whereArgs: [date.toString()]);
+    //debugPrint(rows[0][Attendance.columnId].toString());
+    return rows.map((row) => getDatabaseHelper().rowToAtt(row)).toList();
+
+    //return [Attendance(2, Date(2021, 04, 20), Time(9, 0, 1))];
+  }
   
   Future<void> initData() async{
     await addStaff(new Staff_info("이아영", "DESIGNER"));

--- a/leavetheoffice/lib/data/database_helper.dart
+++ b/leavetheoffice/lib/data/database_helper.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:leavetheoffice/data/attendance.dart';
 import 'package:leavetheoffice/data/staff_info_data.dart';
 import 'package:path/path.dart';
@@ -68,14 +69,14 @@ class DatabaseHelper {
   }
 
   Attendance rowToAtt(Map<String, dynamic> row) {
-    List<String> date = row[Attendance.columnDate].toString().split("/");
-    List<int> dateInt = date.map((e) => int.parse(e));
+    List<String> date = row[Attendance.columnDate].split("-");
+    List<int> dateInt = date.map((e)=>int.parse(e)).toList();
     List<String> start = row[Attendance.columnStart].toString().split(":");
-    List<int> startInt = start.map((e) => int.parse(e));
+    List<int> startInt = start.map((e) => int.parse(e)).toList();
     List<int> endInt;
-    if (row[Attendance.columnEnd] != null) {
+    if (row[Attendance.columnEnd] != "null") {
       List<String> end = row[Attendance.columnEnd].toString().split(":");
-      endInt = end.map((e) => int.parse(e));
+      endInt = end.map((e) => int.parse(e)).toList();
     } else {
       endInt = null;
     }

--- a/leavetheoffice/lib/data/database_helper.dart
+++ b/leavetheoffice/lib/data/database_helper.dart
@@ -1,8 +1,9 @@
-import 'package:flutter/cupertino.dart';
 import 'package:leavetheoffice/data/attendance.dart';
 import 'package:leavetheoffice/data/staff_info_data.dart';
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
+
+import 'att_data_format.dart';
 
 class DatabaseHelper {
   Database _database;
@@ -19,38 +20,69 @@ class DatabaseHelper {
 
   Future<Database> _init() async {
     String dbPath = join(await getDatabasesPath(), _dbName);
-    return openDatabase(dbPath, version: _version, onCreate: (db, version) async {
-      String sql = '''
+    return openDatabase(dbPath, version: _version,
+        onCreate: (db, version) async {
+      String createMemTable = '''
           CREATE TABLE ${Staff_info.memTableName}(
             ${Staff_info.columnId} INTEGER PRIMARY KEY AUTOINCREMENT,
             ${Staff_info.columnName} TEXT NOT NULL,
             ${Staff_info.columnRole} TEXT NOT NULL
           );
+          ''';
+      String createAttTable = '''
           CREATE TABLE ${Attendance.attTableName}(
             ${Attendance.columnId} INTEGER,
             ${Attendance.columnDate} TEXT,
-            ${Attendance.columnStart} TEXT,
+            ${Attendance.columnStart} TEXT NOT NULL,
             ${Attendance.columnEnd} TEXT,
-            FOREIGN KEY (${Attendance.columnId}) REFERENCES ${Staff_info.memTableName}(${Staff_info.columnId}),
-            PRIMARY KEY(${Attendance.columnId}, ${Attendance.columnDate})
+            PRIMARY KEY (${Attendance.columnId}, ${Attendance.columnDate}),
+            FOREIGN KEY (${Attendance.columnId}) REFERENCES ${Staff_info.memTableName}(${Staff_info.columnId})
+              ON DELETE CASCADE 
+              ON UPDATE NO ACTION
           );
           ''';
-      return db.execute(sql);
+      await db.execute(createMemTable);
+      await db.execute(createAttTable);
     });
   }
 
   Map<String, dynamic> memToRow(Staff_info info) {
-    debugPrint(info.name);
     return {
-      Staff_info.columnId: info.id,
       Staff_info.columnName: info.name,
       Staff_info.columnRole: info.roll,
     };
   }
 
   Staff_info rowToMem(Map<String, dynamic> row) {
-    debugPrint(row.isNotEmpty ? "row is not empty" : "row empty");
     return Staff_info(row[Staff_info.columnName], row[Staff_info.columnRole],
         id: row[Staff_info.columnId]);
+  }
+
+  Map<String, dynamic> attToRow(Attendance att) {
+    return {
+      Attendance.columnId: att.id,
+      Attendance.columnDate: att.date.toString(),
+      Attendance.columnStart: att.start.toString(),
+      Attendance.columnEnd: att.end.toString(),
+    };
+  }
+
+  Attendance rowToAtt(Map<String, dynamic> row) {
+    List<String> date = row[Attendance.columnDate].toString().split("/");
+    List<int> dateInt = date.map((e) => int.parse(e));
+    List<String> start = row[Attendance.columnStart].toString().split(":");
+    List<int> startInt = start.map((e) => int.parse(e));
+    List<int> endInt;
+    if (row[Attendance.columnEnd] != null) {
+      List<String> end = row[Attendance.columnEnd].toString().split(":");
+      endInt = end.map((e) => int.parse(e));
+    } else {
+      endInt = null;
+    }
+    return new Attendance(
+        row[Attendance.columnId],
+        Date(dateInt[0], dateInt[1], dateInt[2]),
+        Time(startInt[0], startInt[1], startInt[2]),
+        end: endInt == null ? null : Time(endInt[0], endInt[1], endInt[2]));
   }
 }

--- a/leavetheoffice/lib/data/database_helper.dart
+++ b/leavetheoffice/lib/data/database_helper.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:leavetheoffice/data/attendance.dart';
 import 'package:leavetheoffice/data/staff_info_data.dart';
 import 'package:path/path.dart';
@@ -20,9 +19,11 @@ class DatabaseHelper {
   }
 
   Future<Database> _init() async {
+    // 데이터베이스 초기 설정
     String dbPath = join(await getDatabasesPath(), _dbName);
     return openDatabase(dbPath, version: _version,
         onCreate: (db, version) async {
+      // 스탭 정보를 저장하는 테이블 생성 쿼리
       String createMemTable = '''
           CREATE TABLE ${Staff_info.memTableName}(
             ${Staff_info.columnId} INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -30,6 +31,7 @@ class DatabaseHelper {
             ${Staff_info.columnRole} TEXT NOT NULL
           );
           ''';
+      //근태 기록을 저장하는 테이블 생성 쿼리
       String createAttTable = '''
           CREATE TABLE ${Attendance.attTableName}(
             ${Attendance.columnId} INTEGER,
@@ -48,6 +50,7 @@ class DatabaseHelper {
   }
 
   Map<String, dynamic> memToRow(Staff_info info) {
+    // Staff_info 클래스를 row 형식으로 바꿈
     return {
       Staff_info.columnName: info.name,
       Staff_info.columnRole: info.roll,
@@ -55,11 +58,13 @@ class DatabaseHelper {
   }
 
   Staff_info rowToMem(Map<String, dynamic> row) {
+    // row 형식 데이터를 Staff_info 형식으로 바꿈
     return Staff_info(row[Staff_info.columnName], row[Staff_info.columnRole],
         id: row[Staff_info.columnId]);
   }
 
   Map<String, dynamic> attToRow(Attendance att) {
+    // Attendance 형식 데이터를 row 형식 데이터로 바꿈
     return {
       Attendance.columnId: att.id,
       Attendance.columnDate: att.date.toString(),
@@ -69,6 +74,7 @@ class DatabaseHelper {
   }
 
   Attendance rowToAtt(Map<String, dynamic> row) {
+    // row 형식 데이터를 Attendance 형식 데이터로 바꿈
     List<String> date = row[Attendance.columnDate].split("-");
     List<int> dateInt = date.map((e)=>int.parse(e)).toList();
     List<String> start = row[Attendance.columnStart].toString().split(":");

--- a/leavetheoffice/lib/data/database_helper.dart
+++ b/leavetheoffice/lib/data/database_helper.dart
@@ -34,7 +34,6 @@ class DatabaseHelper {
             FOREIGN KEY (${Attendance.columnId}) REFERENCES ${Staff_info.memTableName}(${Staff_info.columnId}),
             PRIMARY KEY(${Attendance.columnId}, ${Attendance.columnDate})
           );
-          INSERT INTO ${Staff_info.memTableName} (${Staff_info.columnName}, ${Staff_info.columnRole}) VALUES ('insert', 'test');
           ''';
       return db.execute(sql);
     });

--- a/leavetheoffice/lib/data/database_helper.dart
+++ b/leavetheoffice/lib/data/database_helper.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/cupertino.dart';
+import 'package:leavetheoffice/data/attendance.dart';
+import 'package:leavetheoffice/data/staff_info_data.dart';
+import 'package:path/path.dart';
+import 'package:sqflite/sqflite.dart';
+
+class DatabaseHelper {
+  Database _database;
+
+  static const String _dbName = "leaveTheOffice_lab254.db";
+  static const int _version = 1;
+
+  Future<Database> getDatabase() async {
+    if (_database == null) {
+      _database = await _init();
+    }
+    return _database;
+  }
+
+  Future<Database> _init() async {
+    String dbPath = join(await getDatabasesPath(), _dbName);
+    return openDatabase(dbPath, version: _version, onCreate: (db, version) async {
+      String sql = '''
+          CREATE TABLE ${Staff_info.memTableName}(
+            ${Staff_info.columnId} INTEGER PRIMARY KEY AUTOINCREMENT,
+            ${Staff_info.columnName} TEXT NOT NULL,
+            ${Staff_info.columnRole} TEXT NOT NULL
+          );
+          CREATE TABLE ${Attendance.attTableName}(
+            ${Attendance.columnId} INTEGER,
+            ${Attendance.columnDate} TEXT,
+            ${Attendance.columnStart} TEXT,
+            ${Attendance.columnEnd} TEXT,
+            FOREIGN KEY (${Attendance.columnId}) REFERENCES ${Staff_info.memTableName}(${Staff_info.columnId}),
+            PRIMARY KEY(${Attendance.columnId}, ${Attendance.columnDate})
+          );
+          INSERT INTO ${Staff_info.memTableName} (${Staff_info.columnName}, ${Staff_info.columnRole}) VALUES ('insert', 'test');
+          ''';
+      return db.execute(sql);
+    });
+  }
+
+  Map<String, dynamic> memToRow(Staff_info info) {
+    debugPrint(info.name);
+    return {
+      Staff_info.columnId: info.id,
+      Staff_info.columnName: info.name,
+      Staff_info.columnRole: info.roll,
+    };
+  }
+
+  Staff_info rowToMem(Map<String, dynamic> row) {
+    debugPrint(row.isNotEmpty ? "row is not empty" : "row empty");
+    return Staff_info(row[Staff_info.columnName], row[Staff_info.columnRole],
+        id: row[Staff_info.columnId]);
+  }
+}

--- a/leavetheoffice/lib/data/staff_info_data.dart
+++ b/leavetheoffice/lib/data/staff_info_data.dart
@@ -36,11 +36,12 @@ class Staff_info {
   }
 
   // DB
-  void setStartTime(DateTime now){
+  void setStartTime(DateTime now, {bool isSaved = false}){
     _att = new Attendance(id, Date(now.year, now.month, now.day), Time(now.hour, now.minute, now.second));
     isWorking = true;
     startTimeSec = now.hour * 360 + now.minute * 60 + now.second;
-    getDataManager().addAttData(_att);
+    if(!isSaved)
+      getDataManager().addAttData(_att);
   }
 
   void setEndTime(DateTime now){

--- a/leavetheoffice/lib/data/staff_info_data.dart
+++ b/leavetheoffice/lib/data/staff_info_data.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
+import 'package:leavetheoffice/data/att_data_format.dart';
 import 'package:leavetheoffice/data/attendance.dart';
+import 'package:leavetheoffice/provider.dart';
 
 class Staff_info {
   // 기본 정보
@@ -24,6 +26,7 @@ class Staff_info {
   Staff_info(String name, String role, {int id}) {
     this.name = name;
     this.roll = role;
+    this.id = id;
     this.isWorking = false;   // 출근시간이 NOT NULL이고 퇴근시간이 NULL
                               // (_workStartTime != null && _workEndTime == null)일 때 TRUE
   }
@@ -33,13 +36,17 @@ class Staff_info {
   }
 
   // DB
-  void setStartTime(DateTime time){
-    _workStartTime = time;
-    startTimeSec = time.hour * 360 + time.minute * 60 + time.second;
+  void setStartTime(DateTime now){
+    _att = new Attendance(id, Date(now.year, now.month, now.day), Time(now.hour, now.minute, now.second));
+    isWorking = true;
+    startTimeSec = now.hour * 360 + now.minute * 60 + now.second;
+    getDataManager().addAttData(_att);
   }
 
-  void setEndTime(DateTime time){
-    _workEndTime = time;
+  void setEndTime(DateTime now){
+    _att.end = Time(now.hour, now.minute, now.second);
+    isWorking = false;
+    getDataManager().updateAttData(_att, id, _att.date);
   }
 
   // Timer

--- a/leavetheoffice/lib/data/staff_info_data.dart
+++ b/leavetheoffice/lib/data/staff_info_data.dart
@@ -1,12 +1,30 @@
+import 'dart:async';
+
 class Staff_info {
-
   String name;
-
   String roll;
 
-  Staff_info(
-      this.name,
-      this.roll,
-      );
+  DateTime _workStartTime, _workEndTime;
+  int startTimeSec;
+  Timer timer;
+  bool isWorking;
 
+  Staff_info(name, roll) {
+    this.name = name;
+    this.roll = roll;
+    this.isWorking = false;
+  }
+
+  void switchIsWorking(){
+    this.isWorking = !this.isWorking;
+  }
+
+  void setStartTime(DateTime time){
+    _workStartTime = time;
+    startTimeSec = time.hour * 360 + time.minute * 60 + time.second;
+  }
+
+  void setEndTime(DateTime time){
+    _workEndTime = time;
+  }
 }

--- a/leavetheoffice/lib/data/staff_info_data.dart
+++ b/leavetheoffice/lib/data/staff_info_data.dart
@@ -27,4 +27,12 @@ class Staff_info {
   void setEndTime(DateTime time){
     _workEndTime = time;
   }
+
+  void startTimer(Timer timer){
+    this.timer = timer;
+  }
+
+  void endTimer(){
+    this.timer?.cancel();
+  }
 }

--- a/leavetheoffice/lib/data/staff_info_data.dart
+++ b/leavetheoffice/lib/data/staff_info_data.dart
@@ -1,21 +1,31 @@
 import 'dart:async';
 
+import 'package:leavetheoffice/data/attendance.dart';
+
 class Staff_info {
   // 기본 정보
+  int id;
   String name;
   String roll;
 
-  DateTime _workStartTime, _workEndTime;   // DB 저장용
+  // DB
+  static const String memTableName = "members";  //table name
+  static const String columnId = "id";           //primary key
+  static const String columnName = "name";
+  static const String columnRole = "role";
+  DateTime _workStartTime, _workEndTime;
 
   // 시간 계산
+  Attendance _att;
   int startTimeSec;
   Timer timer;
   bool isWorking;
 
-  Staff_info(name, roll) {
+  Staff_info(String name, String role, {int id}) {
     this.name = name;
-    this.roll = roll;
-    this.isWorking = false;   // DB 연결하면 퇴근시간이 NULL일 때 TRUE로 설정
+    this.roll = role;
+    this.isWorking = false;   // 출근시간이 NOT NULL이고 퇴근시간이 NULL
+                              // (_workStartTime != null && _workEndTime == null)일 때 TRUE
   }
 
   void switchIsWorking(){

--- a/leavetheoffice/lib/data/staff_info_data.dart
+++ b/leavetheoffice/lib/data/staff_info_data.dart
@@ -1,10 +1,13 @@
 import 'dart:async';
 
 class Staff_info {
+  // 기본 정보
   String name;
   String roll;
 
-  DateTime _workStartTime, _workEndTime;
+  DateTime _workStartTime, _workEndTime;   // DB 저장용
+
+  // 시간 계산
   int startTimeSec;
   Timer timer;
   bool isWorking;
@@ -12,13 +15,14 @@ class Staff_info {
   Staff_info(name, roll) {
     this.name = name;
     this.roll = roll;
-    this.isWorking = false;
+    this.isWorking = false;   // DB 연결하면 퇴근시간이 NULL일 때 TRUE로 설정
   }
 
   void switchIsWorking(){
     this.isWorking = !this.isWorking;
   }
 
+  // DB
   void setStartTime(DateTime time){
     _workStartTime = time;
     startTimeSec = time.hour * 360 + time.minute * 60 + time.second;
@@ -28,6 +32,7 @@ class Staff_info {
     _workEndTime = time;
   }
 
+  // Timer
   void startTimer(Timer timer){
     this.timer = timer;
   }

--- a/leavetheoffice/lib/page/main_page.dart
+++ b/leavetheoffice/lib/page/main_page.dart
@@ -1,6 +1,5 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:leavetheoffice/components/header_component.dart';
 import 'package:leavetheoffice/components/staff_list_component.dart';
 
@@ -12,6 +11,7 @@ class MainPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    SystemChrome.setEnabledSystemUIOverlays ([]);
     return Scaffold(
       appBar: AppBar(
         centerTitle: true,

--- a/leavetheoffice/lib/page/main_page.dart
+++ b/leavetheoffice/lib/page/main_page.dart
@@ -2,13 +2,22 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:leavetheoffice/components/header_component.dart';
 import 'package:leavetheoffice/components/staff_list_component.dart';
+import 'package:leavetheoffice/data/staff_info_data.dart';
+import 'package:leavetheoffice/provider.dart';
 
 import '../components/header_component.dart';
 import '../components/staff_list_component.dart';
 
-class MainPage extends StatelessWidget {
+class MainPage extends StatefulWidget {
   static const routeName = '/';
 
+  @override
+  State createState() {
+    return _MainPageState();
+  }
+}
+
+class _MainPageState extends State<MainPage>{
   @override
   Widget build(BuildContext context) {
 

--- a/leavetheoffice/lib/page/main_page.dart
+++ b/leavetheoffice/lib/page/main_page.dart
@@ -1,29 +1,28 @@
+import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:leavetheoffice/components/header_component.dart';
 import 'package:leavetheoffice/components/staff_list_component.dart';
 
-class MainPage extends StatelessWidget{
+import '../components/header_component.dart';
+import '../components/staff_list_component.dart';
 
+class MainPage extends StatelessWidget {
   static const routeName = '/';
 
   @override
   Widget build(BuildContext context) {
-
     return Scaffold(
       appBar: AppBar(
         centerTitle: true,
         title: Text("앵무시계"),
       ),
       body: Center(
-        child: Column(
-          children: <Widget>[
-            Header(),
-            StaffList(),
-          ],
-        ),
+        child: Column(children: [
+          Header(),
+          StaffList(),
+        ]),
       ),
     );
-
   }
 }

--- a/leavetheoffice/lib/page/main_page.dart
+++ b/leavetheoffice/lib/page/main_page.dart
@@ -2,8 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:leavetheoffice/components/header_component.dart';
 import 'package:leavetheoffice/components/staff_list_component.dart';
-import 'package:leavetheoffice/data/staff_info_data.dart';
-import 'package:leavetheoffice/provider.dart';
 
 import '../components/header_component.dart';
 import '../components/staff_list_component.dart';
@@ -36,7 +34,6 @@ class _MainPageState extends State<MainPage>{
           StaffList(),
         ]),
       ),
-
     );
   }
 }

--- a/leavetheoffice/lib/page/main_page.dart
+++ b/leavetheoffice/lib/page/main_page.dart
@@ -11,18 +11,23 @@ class MainPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+
+    // 어플리케이션 전체화면 설정
     SystemChrome.setEnabledSystemUIOverlays ([]);
+
     return Scaffold(
       appBar: AppBar(
         centerTitle: true,
         title: Text("앵무시계"),
       ),
+
       body: Center(
         child: Column(children: [
           Header(),
           StaffList(),
         ]),
       ),
+
     );
   }
 }

--- a/leavetheoffice/lib/page/main_page.dart
+++ b/leavetheoffice/lib/page/main_page.dart
@@ -6,7 +6,7 @@ import 'package:leavetheoffice/components/staff_list_component.dart';
 import '../components/header_component.dart';
 import '../components/staff_list_component.dart';
 
-class MainPage extends StatefulWidget {
+class MainPage extends StatefulWidget {   // Future builder component를 사용하려면 StatefulWidget이어야 함
   static const routeName = '/';
 
   @override

--- a/leavetheoffice/lib/provider.dart
+++ b/leavetheoffice/lib/provider.dart
@@ -1,11 +1,23 @@
 import 'package:leavetheoffice/data/data_manager.dart';
+import 'package:leavetheoffice/data/database_helper.dart';
 
 DataManager _dataManager;
+DatabaseHelper _databaseHelper;
 
-// DataManager는 앱 실행 최초 1회 생성
+// DataManager, DbHelper는 앱 실행 최초 1회 생성
 DataManager getDataManager(){
   if(_dataManager == null){
     _dataManager = new DataManager();
+    _dataManager.init();
   }
+
   return _dataManager;
+}
+
+DatabaseHelper getDatabaseHelper(){
+  if(_databaseHelper == null){
+    _databaseHelper = new DatabaseHelper();
+  }
+
+  return _databaseHelper;
 }

--- a/leavetheoffice/lib/provider.dart
+++ b/leavetheoffice/lib/provider.dart
@@ -1,0 +1,10 @@
+import 'package:leavetheoffice/data/data_manager.dart';
+
+DataManager _dataManager;
+
+DataManager getDataManager(){
+  if(_dataManager == null){
+    _dataManager = new DataManager();
+  }
+  return _dataManager;
+}

--- a/leavetheoffice/lib/provider.dart
+++ b/leavetheoffice/lib/provider.dart
@@ -2,6 +2,7 @@ import 'package:leavetheoffice/data/data_manager.dart';
 
 DataManager _dataManager;
 
+// DataManager는 앱 실행 최초 1회 생성
 DataManager getDataManager(){
   if(_dataManager == null){
     _dataManager = new DataManager();

--- a/leavetheoffice/lib/provider.dart
+++ b/leavetheoffice/lib/provider.dart
@@ -8,7 +8,6 @@ DatabaseHelper _databaseHelper;
 DataManager getDataManager(){
   if(_dataManager == null){
     _dataManager = new DataManager();
-    _dataManager.init();
   }
 
   return _dataManager;

--- a/leavetheoffice/pubspec.yaml
+++ b/leavetheoffice/pubspec.yaml
@@ -24,6 +24,8 @@ dependencies:
   flutter:
     sdk: flutter
   intl: ^0.17.0
+  sqflite: ^1.3.0
+  path: ^1.8.0
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
- 근무 시간 화면 출력 기능 구현
'출근하기' 버튼 클릭 시 해당 staff component에서 타이머 동작
타이머 숫자가 바뀔 때마다 화면 갱신

- 퇴근하기 버튼 기능 구현
'퇴근하기' 버튼 상태일 때 클릭 시 팝업으로 퇴근 여부를 질의
확인 누를 시 타이머가 초기화됨 (퇴근하기를 누른 날은 해당 버튼을 비활성화 하는 방향도 고려)

- 화면 관련 이슈 해결
그리드 뷰 스크롤 시 화면에 표시되지 않는 데이터는 초기화되는 문제 해결

- SQLite API 추가
SQLite 추가하여 사용할 테이블 생성 (1. 스텝 정보 관리하는 테이블, 2. 근태 기록 관리하는 테이블)
테이블 별 기본 함수 구현(CRUD / row-class conversion)
기본 함수와 UI 연결 (ex. '출근하기' 버튼 클릭 -> 근태 관리 테이블에 출근 시간 데이터 추가)

- 근무시간 중 애플리케이션이 종료되었을 때 데이터베이스에서 기존 기록 불러오는 기능 구현
근태 관리 테이블에서 당일 기록을 조회
해당 스탭의 출근 기록이 이미 있으면서 퇴근 기록이 없으면 애플리케이션의 비정상적인 종료로 간주, 기존 출근 기록에 이어서 근무 시간 출력